### PR TITLE
LIBMOBILE-1276- Bump up analytics-kotlin version to latest.

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -9,13 +9,13 @@ plugins {
 val VERSION_NAME: String by project
 
 android {
-    compileSdk = 31
-    buildToolsVersion = "31.0.0"
+    compileSdk = 33
+    buildToolsVersion = "33.0.1"
 
     defaultConfig {
         multiDexEnabled = true
         minSdk = 21
-        targetSdk = 31
+        targetSdk = 33
 
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("proguard-consumer-rules.pro")
@@ -42,9 +42,9 @@ android {
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
 
-    implementation("com.segment.analytics.kotlin:android:1.6.2")
+    implementation("com.segment.analytics.kotlin:android:1.10.3")
     implementation("androidx.multidex:multidex:2.0.1")
-    implementation("androidx.core:core-ktx:1.7.0")
+    implementation("androidx.core:core-ktx:1.9.0")
 
     implementation("androidx.lifecycle:lifecycle-process:2.4.1")
     implementation("androidx.lifecycle:lifecycle-common-java8:2.4.1")
@@ -52,18 +52,18 @@ dependencies {
 
 // Partner Dependencies
 dependencies {
-    api("com.comscore:android-analytics:6.5.0")
+    api("com.comscore:android-analytics:6.9.2")
 }
 
 // Test Dependencies
 dependencies {
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
     testImplementation("io.mockk:mockk:1.12.4")
 
     // Add Roboelectric dependencies.
     testImplementation("org.robolectric:robolectric:4.7.3")
-    testImplementation("androidx.test:core:1.4.0")
+    testImplementation("androidx.test:core:1.5.0")
 
     // Add JUnit4 legacy dependencies.
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.8.2")
@@ -77,8 +77,8 @@ dependencies {
 
 // Android Test Deps
 dependencies {
-    androidTestImplementation("androidx.test.ext:junit:1.1.3")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }
 
 // required for mvn-publish

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
 
     implementation("com.segment.analytics.kotlin:android:1.10.3")
     implementation("androidx.multidex:multidex:2.0.1")
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.7.0")
 
     implementation("androidx.lifecycle:lifecycle-process:2.4.1")
     implementation("androidx.lifecycle:lifecycle-common-java8:2.4.1")

--- a/lib/src/test/kotlin/com/segment/analytics/kotlin/destinations/comscore/ComscoreDestinationTest.kt
+++ b/lib/src/test/kotlin/com/segment/analytics/kotlin/destinations/comscore/ComscoreDestinationTest.kt
@@ -84,7 +84,7 @@ class ComscoreDestinationTests {
         every { mockedStreamingAnalytics.configuration } returns mockedStreamingConfiguration
 
         mockkStatic(Class.forName("com.segment.analytics.kotlin.core.platform.plugins.logger.LogTargetKt").kotlin)
-        every { mockedAnalytics.log(any(), any(), any(), any()) } just Runs
+        every { mockedAnalytics.log(any(), any()) } just Runs
 
         val comscoreOptionsPlugin = ComscoreOptionsPlugin()
         comscoreDestination.comscoreOptionsPlugin = comscoreOptionsPlugin


### PR DESCRIPTION
LIBMOBILE-1276
- upgraded Analytics version from 1.5.0 to 1.10.3
- upgraded Comscore sdk version from 6.5.0 to 6.9.2
- upgraded target and compile SDK version from 31 to 33
- upgraded test:core,mockk, test:junit, espresso to latest
- fixed ComscoreDestinationTest error